### PR TITLE
Remove migration script references from cohort docs

### DIFF
--- a/docs/guides/operating_guide.md
+++ b/docs/guides/operating_guide.md
@@ -124,7 +124,9 @@ The system uses CSV-based configuration for easy experiment setup without code c
 
 #### 1. Define the Cohort Spec
 
-Generate or edit the cohort spec under `data/cohorts/<cohort_id>/spec/` to enumerate the concepts, templates, and model allowlists. The easiest way to bootstrap a spec is to run `uv run python scripts/migrations/generate_cohort_spec.py --cohort-id <cohort>` which reads the current catalogs and writes `config.yaml` plus `items/cohort_rows.yaml`. Update those files to reflect the exact combinations you want to materialize.
+Generate or edit the cohort spec under `data/cohorts/<cohort_id>/spec/` (entry point: `config.yaml`) to enumerate the concepts, templates, and model allowlists. Bootstrap options include copying an existing cohort's `spec/` bundle as a starting point or drafting a new `config.yaml` and helper files from scratch.
+
+After editing the spec, re-materialise the cohort assets so the manifest and `membership.csv` stay aligned.
 
 #### 2. Adjust Template Metadata
 
@@ -207,11 +209,11 @@ Cross‑experiment tracking no longer uses auto‑appenders. Use the `filtered_e
    uv run python scripts/select_top_essays.py --cohort-id my-cohort --template novelty --top-n 30
    ```
 2. Edit the resulting CSV (`data/curation/top_essay_candidates.csv` by default), toggling the `selected` column or reordering rows.
-3. Materialise the cohort membership and spec bundle:
+3. Materialise the cohort membership CSV:
    ```bash
    uv run python scripts/build_cohort_from_list.py --cohort-id my-cohort
    ```
-   The curated list is copied to `data/cohorts/<id>/curation/` for traceability before the usual Dagster assets consume the generated spec.
+   The curated list is copied to `data/cohorts/<id>/curation/` for traceability and `membership.csv` is written under `data/cohorts/<id>/`. Copy or author `spec/config.yaml` for the cohort, then re-run the cohort assets so Dagster registers partitions for the new rows (see `docs/cohorts.md`).
 
 ---
 

--- a/docs/spec_dsl.md
+++ b/docs/spec_dsl.md
@@ -11,9 +11,8 @@ Highlights:
 - Rule pipeline (`subset → tie → pair → tuple`) to bound Cartesian growth.
 - Explicit replicate axes (e.g., `draft_template_replicate`) keep deterministic indices visible in the spec.
 - CLI (`scripts/compile_experiment_design.py`) for producing CSV/JSONL output with catalog data sourced from JSON/CSV files.
-- Cohort integration: `cohort_membership` loads spec bundles via `daydreaming_dagster.cohorts.load_cohort_definition` when `data/cohorts/<cohort_id>/spec/` is present, ensuring spec + catalogs fully determine cohort rows.
+- Cohort integration: `cohort_membership` loads `data/cohorts/<cohort_id>/spec/config.yaml` via `daydreaming_dagster.cohorts.load_cohort_definition`, ensuring the spec plus catalogs fully determine cohort rows.
 - In-memory parsing via `parse_spec_mapping` for tests and dependency-injection scenarios where writing spec files is unnecessary.
-- Migration helper (`scripts/migrations/generate_cohort_spec.py`) snapshotting existing cohorts into spec bundles so legacy runs can adopt the DSL without manual transcription.
 
 ### Why this design?
 
@@ -29,7 +28,7 @@ Top-level keys supported by `load_spec` / CLI:
 | `rules` | mapping | Optional. Sectioned by rule type (`subsets`, `ties`, `pairs`, `tuples`). The loader converts each section into the canonical rule pipeline order. |
 | `output` | mapping | Optional. Currently used for column ordering (`field_order`) and shuffle seed. |
 
-> Specs must be single files. Directory bundles (`spec/axes/*.txt`, `spec/rules/*.yaml`) are no longer supported—use `@file:` references instead.
+> Specs are single files (e.g., `spec/config.yaml`) that can reference sibling helpers via `@file:`. Pure directory bundles (`spec/axes/*.txt`, `spec/rules/*.yaml` without a config entry point) are no longer supported.
 
 To parse pre-loaded mappings (e.g., during tests), call `parse_spec_mapping(mapping, source=..., base_dir=...)`. The helper shares validation with `load_spec` while letting callers avoid temporary files.
 


### PR DESCRIPTION
## Summary
- Documented that cohort specs are rooted at `spec/config.yaml` and link to `docs/cohorts.md` as the canonical lifecycle reference.
- Updated architecture and operating guides to clarify that downstream code relies on `membership.csv` and describe manual cohort spec curation without migration scripts.
- Refreshed the spec DSL reference to explain the config entry point and the supported helper files in cohort spec directories while removing temporary migration tooling references.

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68e37913b5cc83289287cba266786d1e