### PR TITLE
Ensure Dagster doc examples include partition flag

### DIFF
--- a/docs/guides/one_phase_copy_mode.md
+++ b/docs/guides/one_phase_copy_mode.md
@@ -19,10 +19,10 @@ Setup
    - Catalog mode: ensure `data/combo_mappings.csv` contains the desired combos and materialize `cohort_id` (which writes the manifest) followed by `selected_combo_mappings`/`content_combinations` to hydrate combo content:
      - `uv run dagster asset materialize --select "cohort_id,selected_combo_mappings,content_combinations,cohort_membership" -f src/daydreaming_dagster/definitions.py`
 3) Materialize partitions
-   - Drafts: `uv run dagster asset materialize --select "group:generation_draft" -f src/daydreaming_dagster/definitions.py`
-   - Essays (copy mode): `uv run dagster asset materialize --select "group:generation_essays" -f src/daydreaming_dagster/definitions.py`
+   - Drafts: `uv run dagster asset materialize --select "group:generation_draft" --partition "<draft_gen_id>" -f src/daydreaming_dagster/definitions.py`
+   - Essays (copy mode): `uv run dagster asset materialize --select "group:generation_essays" --partition "<essay_gen_id>" -f src/daydreaming_dagster/definitions.py`
      - The `essay_prompt` will surface `COPY_MODE: ...` and the `essay_raw`/`essay_parsed` assets will copy the parsed draft content.
-   - Evaluations: `uv run dagster asset materialize --select "group:evaluation" -f src/daydreaming_dagster/definitions.py`
+   - Evaluations: `uv run dagster asset materialize --select "group:evaluation" --partition "<evaluation_gen_id>" -f src/daydreaming_dagster/definitions.py`
 4) Results
    - Parse and summarize: `uv run dagster asset materialize --select "parsed_scores,final_results" -f src/daydreaming_dagster/definitions.py`
 

--- a/docs/guides/operating_guide.md
+++ b/docs/guides/operating_guide.md
@@ -178,13 +178,15 @@ Optionally stash selection files for traceability:
 2. **Run generation assets:**
    ```bash
    uv run dagster asset materialize -f src/daydreaming_dagster/definitions.py \
-    --select "group:generation_draft,group:generation_essays"
+    --select "group:generation_draft,group:generation_essays" \
+    --partition "<gen_id>"
    ```
 
 3. **Run evaluation assets:**
    ```bash
    uv run dagster asset materialize -f src/daydreaming_dagster/definitions.py \
-    --select "group:evaluation"
+    --select "group:evaluation" \
+    --partition "<evaluation_gen_id>"
    ```
 
 4. **Process results and run analysis:**
@@ -291,11 +293,13 @@ Then materialize generation in two steps:
 # Free-tier generation (serialized globally)
 uv run dagster asset materialize -f src/daydreaming_dagster/definitions.py \
   --select "content_combinations,draft_prompt,draft_raw,draft_parsed" \
+  --partition "<draft_gen_id>" \
   --tag experiment_id=exp_free_vs_paid
 
 # Paid generation (parallel per pool)
 uv run dagster asset materialize -f src/daydreaming_dagster/definitions.py \
   --select "content_combinations,draft_prompt,draft_raw,draft_parsed" \
+  --partition "<draft_gen_id>" \
   --tag experiment_id=exp_free_vs_paid
 ```
 
@@ -303,6 +307,7 @@ For evaluation with a paid model:
 ```bash
 uv run dagster asset materialize -f src/daydreaming_dagster/definitions.py \
   --select "evaluation_prompt,evaluation_raw,evaluation_parsed" \
+  --partition "<evaluation_gen_id>" \
   --tag experiment_id=exp_free_vs_paid
 ```
 


### PR DESCRIPTION
## Summary
- add explicit `--partition` placeholders to copy-mode generation and evaluation commands
- update operating guide examples so partitioned Dagster assets always document the required `--partition`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e39b4c3058832896c635d547121703