### PR TITLE
Update README goal link placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # DayDreaming Dagster Pipeline
 
-Dagster-based pipeline exploring whether offline LLMs can reinvent the “Daydreaming Loop” via structured, two-phase generation and evaluation.
+Dagster-based pipeline exploring whether offline LLMs can reinvent the “Daydreaming Loop” via structured, two-phase generation and evaluation. For the full set of project goals and guiding questions, start with [`docs/theory/project_goals.md`](docs/theory/project_goals.md).
 
 ## Start Here
 
-DayDreaming treats **cohorts** as the contract between planning and execution. A cohort is a bundle of specs (YAML defined in [`docs/spec_dsl.md`](docs/spec_dsl.md)) that enumerates which prompts, models, and replicas we want to evaluate. The Dagster assets compile that spec into deterministic generation IDs and results on disk. To get oriented:
+DayDreaming treats **cohorts** as the contract between planning and execution. A cohort is a bundle of specs (YAML defined in [`docs/spec_dsl.md`](docs/spec_dsl.md)) that enumerates which prompts, models, and replicas we want to evaluate. The Dagster assets compile that spec into deterministic generation IDs and results on disk. To get oriented on how the pieces fit together:
 
-1. **Understand the why.** Start with the project goals to see how the "Daydreaming" loop blends drafting, essaying, and evaluation. [`docs/theory/project_goals.md`](docs/theory/project_goals.md)
-2. **Learn what a spec contains.** Read the spec DSL guide to see how axes, allowlists, and structured couplings are authored. Most feature work involves extending these specs. [`docs/spec_dsl.md`](docs/spec_dsl.md)
-3. **Follow the cohort lifecycle.** The cohorts guide explains how specs become manifests, `membership.csv`, and seeded generation metadata. It is the primary contract the code relies on. [`docs/cohorts.md`](docs/cohorts.md)
-4. **Map the implementation.** Once the contract is clear, dive into the architecture overview to see which modules load the cohort bundle, register partitions, and run the unified stage pipeline. [`docs/architecture.md`](docs/architecture.md)
-5. **Stay operational.** Keep the operating guide nearby for Dagster commands, partition tips, and maintenance tasks. [`docs/guides/operating_guide.md`](docs/guides/operating_guide.md)
+1. **Learn what a spec contains.** Read the spec DSL guide to see how axes, allowlists, and structured couplings are authored. Most feature work involves extending these specs. [`docs/spec_dsl.md`](docs/spec_dsl.md)
+2. **Follow the cohort lifecycle.** The cohorts guide explains how specs become manifests, `membership.csv`, and seeded generation metadata. It is the primary contract the code relies on. [`docs/cohorts.md`](docs/cohorts.md)
+3. **Map the implementation.** Once the contract is clear, dive into the architecture overview to see which modules load the cohort bundle, register partitions, and run the unified stage pipeline. [`docs/architecture.md`](docs/architecture.md)
+4. **Stay operational.** Keep the operating guide nearby for Dagster commands, partition tips, and maintenance tasks. [`docs/guides/operating_guide.md`](docs/guides/operating_guide.md)
 
 Everything else in this README focuses on getting the environment running; the docs above carry the authoritative details for planning experiments and navigating the code.
 


### PR DESCRIPTION
## Summary
- link the project goals document from the opening description in the README
- refocus the "Start Here" section on how to work with cohorts and supporting docs

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e3e1b4115c8328b3a2bfa2d084b830